### PR TITLE
Add concourse pipeline to build docker images

### DIFF
--- a/.concourse/.gitignore
+++ b/.concourse/.gitignore
@@ -1,0 +1,1 @@
+/config.yaml

--- a/.concourse/README.md
+++ b/.concourse/README.md
@@ -1,0 +1,36 @@
+# eirinix-helm-release pipeline
+
+[This pipeline] builds the SUSE Eirini extensions docker images, as well as
+building the SUSE Eirini extensions helm chart.  They are for use with [kubecf].
+
+[This pipeline]: https://concourse.suse.dev/teams/main/pipelines/eirinix
+[kubecf]: https://code.cloudfoundry.org/kubecf
+
+## Deploying the pipeline
+
+### Prerequisites
+
+Deploying this pipeline requires a [concourse] installation, as well as having
+[gomplate] available locally.
+
+[concourse]: https:/concourse-ci.org/
+[gomplate]: https://gomplate.ca/
+
+The concourse [credential manager] is also required to have the
+`docker-username` and `docker-password` credentials available.
+
+[credential manager]: https://concourse-ci.org/creds.html
+
+### Deploy on concourse
+
+Deploy the pipeline using the `fly` script in this directory:
+
+```bash
+./fly -t target set-pipeline
+```
+
+### Pipeline development
+
+If you wish to deploy a copy of this pipeline for development (without
+publishing) artifacts to the official places), create a `configl.yaml` file
+based on `config.yaml.sample` and deploy normally.

--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -1,0 +1,18 @@
+# All values are optional; if not provided, hard-coded production values in the
+# pipeline are used.
+
+docker:
+  org: ~ # cfcontainerization
+
+git:
+  user: ~  # SUSE CFCIBot
+  email: ~ # cf-ci-bot@suse.de
+
+repos:
+  trigger: false            # whether to automatically trigger builds
+  org: ~                    # SUSE
+  # Per-repo overrides are also possible; these include the org.
+  loggregator-bridge: ~     # SUSE/eirini-loggregator-bridge
+  persi: ~                  # SUSE/eirini-persi
+  persi-broker: ~           # SUSE/eirini-persi-broker
+  ssh: ~                    # SUSE/eirini-ssh

--- a/.concourse/fly
+++ b/.concourse/fly
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# This script should be used instead of Concourse "fly" cli in order to deploy
+# the pipeline. It simply calls "gomplate" to render the final pipeline definition.
+# It delegated all other options to the real "fly".
+#
+# E.g. ./fly -t target set-pipeline
+
+set -o errtrace -o errexit -o nounset -o pipefail
+
+if ! type -t gomplate >/dev/null ; then
+  echo "gomplate missing. Follow the instructions in https://docs.gomplate.ca/installing/ and install it first."
+  exit 1
+fi
+
+command=( gomplate --verbose --file pipeline.yaml.gomplate )
+pipeline="eirinix"
+if [[ -r config.yaml ]]; then
+  command+=(--context ".=config.yaml")
+  pipeline="${USER}-${pipeline}"
+fi
+
+"${command[@]}" >/dev/null # Check for template rendering failures
+fly "${@}" --config <("${command[@]}") --pipeline "${pipeline}"

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1,0 +1,171 @@
+
+{{/* list of repositories and output images */}}
+
+{{ $repos := slice "loggregator-bridge" "persi" "persi-broker" "ssh" }}
+{{ $images := slice "loggregator-bridge" "persi" "persi-broker" "ssh" "ssh-proxy" }}
+
+{{/* configure default values */}}
+
+{{/* .docker.org */}}
+{{ $ = merge (default "cfcontainerization" $.docker.org | dict "org" | dict "docker") $ }}
+{{/* .git.user */}}
+{{ $ = merge (default "SUSE CFCIBot" $.git.user | dict "user" | dict "git") $ }}
+{{/* .git.email */}}
+{{ $ = merge (default "cf-ci-bot@suse.de" $.git.email | dict "email" | dict "git") $ }}
+{{/* .repos.trigger */}}
+{{ $ = merge (default true $.repos.trigger | dict "trigger" | dict "repos") $ }}
+{{/* .repos.org */}}
+{{ $ = merge (default "SUSE" $.repos.org | dict "org" | dict "repos") $ }}
+{{/* .repos.<repo> */}}
+{{ range $repos }}
+{{ $ = merge (index $.repos . | default (printf "%s/eirini-%s" $.repos.org .) | dict . | dict "repos") $ }}
+{{ end }}
+
+{{/* This template builds a go binary from source */}}
+{{/* Requires `.repo`, `.image`, and `.subdir` keys */}}
+{{ define "direct-build" }}
+- name: {{ $.image }}
+  plan:
+  - get: docker.build-base
+  - get: git.{{ $.repo }}
+    trigger: {{ $.repos.trigger }}
+    version: every
+  - task: build
+    config:
+      platform: linux
+      inputs:
+      - name: src
+      outputs:
+      - name: bin
+      caches:
+      - path: cache
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - >
+          set -o errexit -o nounset -o xtrace ;
+          export GOCACHE=$PWD/cache ;
+          OUTFILE=${PWD}/bin/{{ $.image }} ;
+          cd src ;
+          GO111MODULES=on go mod vendor ;
+          go build -o ${OUTFILE} ./{{ $.subdir }}/
+    image: docker.build-base
+    input_mapping:
+      src: git.{{ $.repo }}
+  - task: image
+    config:
+      platform: linux
+      inputs:
+      - name: bin
+      outputs:
+      - name: image
+      run:
+        path: /usr/bin/tar
+        args: [ cf, image/image.tar, -C, bin, {{ $.image }} ]
+    image: docker.build-base
+  - put: docker.{{ $.image }}
+    params:
+      import_file: image/image.tar
+{{ end }}
+
+groups:
+- name: logging
+  jobs: [ loggregator-bridge ]
+- name: persi
+  jobs: [ persi, persi-broker ]
+- name: ssh
+  jobs: [ ssh-extension, ssh-proxy ]
+
+resources:
+# source GitHub repositories
+{{ range $repos }}
+- name: git.{{ . }}
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/{{ index $.repos . }}
+{{ end }}
+
+# Docker image outputs
+{{ range $images }}
+- name: docker.{{ . }}
+  type: docker-image
+  source:
+    repository: {{ $.docker.org }}/eirinix-{{ . }}
+    username:   ((docker-username))
+    password:   ((docker-password))
+    build_args:
+      user: {{ $.git.user }}
+      email: {{ $.git.email }}
+
+{{ end }}
+
+# Docker image for building images
+- name: docker.build-base
+  type: docker-image
+  source:
+    repository: {{ $.docker.org }}/eirinix-build-base
+    username:   ((docker-username))
+    password:   ((docker-password))
+
+jobs:
+
+# Job to construct docker.build-base
+- name: build-base
+  plan:
+  - task: dockerfile
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: { repository: opensuse/leap }
+      outputs:
+      - name: out
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - echo "${DATA}" > out/Dockerfile
+      params:
+        DATA: |
+          FROM opensuse/leap
+          RUN true \
+            && zypper --non-interactive refresh \
+            && zypper --non-interactive install \
+              git-core \
+              bzr \
+              python-openssl \
+              'go >= 1.12' \
+              tar \
+            && zypper --non-interactive clean
+  - put: docker.build-base
+    params:
+      build: out
+
+{{ if has $images "loggregator-bridge" }}
+- name: loggregator-bridge
+  plan:
+  - get: git.loggregator-bridge
+    trigger: {{ $.repos.trigger }}
+    version: every
+  - put: docker.loggregator-bridge
+    params:
+      build: git.loggregator-bridge
+{{ end }}
+
+{{ if has $images "persi" }}
+{{ template "direct-build" (dict "repo" "persi" "subdir" "cmd/eirini-ext" "image" "persi" | merge $) }}
+{{ end }}
+
+{{ if has $images "persi-broker" }}
+{{ template "direct-build" (dict "repo" "persi-broker" "subdir" "cmd/broker" "image" "persi-broker" | merge $) }}
+{{ end }}
+
+{{ if has $images "ssh" }}
+{{ template "direct-build" (dict "repo" "ssh" "subdir" "cmd/extension" "image" "ssh" | merge $) }}
+{{ end }}
+
+{{ if has $images "ssh-proxy" }}
+{{ template "direct-build" (dict "repo" "ssh" "subdir" "cmd/ssh-proxy" "image" "ssh-proxy" | merge $) }}
+{{ end }}


### PR DESCRIPTION
This adds a concourse pipeline definition to build docker images for the various jobs.  These are, at this point, completely untested.

Note that the loggregator-bridge image needs https://github.com/SUSE/eirini-loggregator-bridge/pull/7 for the build to succeed.