### PR TITLE
Publish charts on GitHub

### DIFF
--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -11,6 +11,8 @@ git:
 repos:
   trigger: false                   # whether to automatically trigger builds
   org: ~                           # SUSE
+  token:                           ((github-access-token))
+  key:                             ((github-private-key))
   # Per-repo overrides are also possible; these include the org.
   eirini-loggregator-bridge: ~     # SUSE/eirini-loggregator-bridge
   eirini-persi: ~                  # SUSE/eirini-persi
@@ -19,12 +21,12 @@ repos:
   eirinix-helm-release: ~          # SUSE/eirinix-helm-release
 
 s3:
-  bucket: eirini-suse
-  prefix: ""
-  access_key_id: ~
-  secret_access_key: ~
-  session_token: ~
-  region_name: us-east-1
-  private: false
-  endpoint: ~
-  disable_ssl: false
+  bucket:            eirini-suse
+  prefix:            ""
+  access_key_id:     ((aws-access-key))
+  secret_access_key: ((aws-secret-key))
+  session_token:     ~
+  region_name:       us-east-1
+  private:           false
+  endpoint:          ~
+  disable_ssl:       false

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -71,8 +71,9 @@
         args:
         - -c
         - >
-          git config --global user.name  $GIT_AUTHOR_NAME ;
-          git config --global user.email $GIT_AUTHOR_EMAIL ;
+          set -o errexit -o nounset ;
+          git config --global user.name  "$GIT_AUTHOR_NAME" ;
+          git config --global user.email "$GIT_AUTHOR_EMAIL" ;
           (
             cd src ;
             if [ -r bin/include/versioning ] ; then
@@ -118,6 +119,12 @@ resources:
     branch: master
     uri: https://github.com/{{ index $.repos . }}
 {{ end }}
+- name: git.chart-repository
+  type: git
+  source:
+    branch: gh-pages
+    uri: git@github.com:{{ index $.repos "eirinix-helm-release" }}
+    private_key: {{ $.repos.key }}
 - name: github-release.chart
   type: github-release
   source:
@@ -256,10 +263,46 @@ jobs:
           setup-image:
             repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
-  - put: github-release.chart
-    params:
-      name: output/version.txt
-      tag: output/version.txt
-      tag_prefix: v
-      commitish: output/commit.txt
-      globs: [ output/eirini-extensions-*.tgz ]
+  - in_parallel:
+    - put: github-release.chart
+      params:
+        name: output/version.txt
+        tag: output/version.txt
+        tag_prefix: v
+        commitish: output/commit.txt
+        globs: [ output/eirini-extensions-*.tgz ]
+    - do:
+      - get: git.chart-repository
+      - task: regenerate-chart-repo
+        config:
+          platform: linux
+          inputs:
+          - name: git.chart-repository
+          - name: output
+          outputs:
+          - name: git.chart-repository
+          params:
+            GIT_AUTHOR_NAME: {{ $.git.user }}
+            GIT_AUTHOR_EMAIL: {{ $.git.email }}
+            FULL_REPO: {{ index $.repos "eirinix-helm-release" }}
+          run:
+            dir: git.chart-repository
+            path: /bin/sh
+            args:
+            - -c
+            - >
+              set -o errexit -o nounset -o xtrace ;
+              VERSION="$(cat ../output/version.txt)" ;
+              ORG="${FULL_REPO%%/*}" ;
+              REPO="${FULL_REPO#*/}" ;
+              URL="https://${ORG}.github.io/${REPO}/" ;
+              cp ../output/eirini-extensions-*.tgz . ;
+              helm repo index --merge index.yaml --url "${URL}" . ;
+              git config --global user.name  "$GIT_AUTHOR_NAME" ;
+              git config --global user.email "$GIT_AUTHOR_EMAIL" ;
+              git add "eirini-extensions-${VERSION}"*.tgz index.yaml ;
+              git commit -m "Add version ${VERSION}" ;
+        image: docker.package-base
+      - put: git.chart-repository
+        params:
+          repository: git.chart-repository

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -80,7 +80,7 @@
               . bin/include/versioning ;
               echo $VERSION_TAG ;
             else
-              git describe --tags --long || \
+              git describe --tags --long --exclude '*+g*' || \
                 printf "v0.0.0-g%s" "$(git describe --always)"
             fi
           ) > tag/tag.txt ;
@@ -102,7 +102,7 @@
 
 groups:
 - name: chart
-  jobs: [ package-base, chart ]
+  jobs: [ package-base, chart, update-repo ]
 - name: logging
   jobs: [ loggregator-bridge ]
 - name: persi
@@ -236,12 +236,11 @@ jobs:
       run:
         dir: git.eirinix-helm-release
         path: bin/package
-        args:
-        - --destination=../output
     image: docker.package-base
     params:
       VERSION_FILE: ../output/version.txt
       COMMIT_HASH_FILE: ../output/commit.txt
+      OUTPUT_DIR: ../output/
       OVERRIDES: |
         {{- range $images }}
         {{- if . | strings.HasSuffix "-setup" | not }}
@@ -263,46 +262,43 @@ jobs:
           setup-image:
             repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
+  - put: github-release.chart
+    params:
+      name: output/version.txt
+      tag: output/version.txt
+      tag_prefix: v
+      commitish: output/commit.txt
+      globs: [ output/eirini-extensions-*.tgz ]
+- name: update-repo
+  serial: true
+  plan:
   - in_parallel:
-    - put: github-release.chart
+    - get: docker.package-base
+    - get: git.eirinix-helm-release
+    - get: git.chart-repository
+    - get: github-release.chart
+      trigger: {{ $.repos.trigger }}
+      passed: [ chart ]
       params:
-        name: output/version.txt
-        tag: output/version.txt
-        tag_prefix: v
-        commitish: output/commit.txt
-        globs: [ output/eirini-extensions-*.tgz ]
-    - do:
-      - get: git.chart-repository
-      - task: regenerate-chart-repo
-        config:
-          platform: linux
-          inputs:
-          - name: git.chart-repository
-          - name: output
-          outputs:
-          - name: git.chart-repository
-          params:
-            GIT_AUTHOR_NAME: {{ $.git.user }}
-            GIT_AUTHOR_EMAIL: {{ $.git.email }}
-            FULL_REPO: {{ index $.repos "eirinix-helm-release" }}
-          run:
-            dir: git.chart-repository
-            path: /bin/sh
-            args:
-            - -c
-            - >
-              set -o errexit -o nounset -o xtrace ;
-              VERSION="$(cat ../output/version.txt)" ;
-              ORG="${FULL_REPO%%/*}" ;
-              REPO="${FULL_REPO#*/}" ;
-              URL="https://${ORG}.github.io/${REPO}/" ;
-              cp ../output/eirini-extensions-*.tgz . ;
-              helm repo index --merge index.yaml --url "${URL}" . ;
-              git config --global user.name  "$GIT_AUTHOR_NAME" ;
-              git config --global user.email "$GIT_AUTHOR_EMAIL" ;
-              git add "eirini-extensions-${VERSION}"*.tgz index.yaml ;
-              git commit -m "Add version ${VERSION}" ;
-        image: docker.package-base
-      - put: git.chart-repository
-        params:
-          repository: git.chart-repository
+        globs: [ eirini-extensions-*.tgz ]
+  - task: regenerate-chart-repo
+    config:
+      platform: linux
+      inputs:
+      - name: git.chart-repository
+      - name: git.eirinix-helm-release
+      - name: github-release.chart
+      outputs:
+      - name: git.chart-repository
+      params:
+        GIT_AUTHOR_NAME: {{ $.git.user }}
+        GIT_AUTHOR_EMAIL: {{ $.git.email }}
+        REPO: {{ index $.repos "eirinix-helm-release" }}
+      run:
+        path: ../git.eirinix-helm-release/bin/update-helm-index.rb
+        dir: git.chart-repository
+        args: [ ../github-release.chart ]
+    image: docker.package-base
+  - put: git.chart-repository
+    params:
+      repository: git.chart-repository

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -256,19 +256,10 @@ jobs:
           setup-image:
             repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
-  - task: release-prep
-    config:
-      platform: linux
-      outputs:
-      - name: release-prep
-      run:
-        path: /bin/sh
-        args: [ -c, "echo -n v > release-prep/tag-prefix.txt" ]
-    image: docker.package-base
   - put: github-release.chart
     params:
       name: output/version.txt
       tag: output/version.txt
-      tag_prefix: release-prep/tag-prefix.txt
+      tag_prefix: v
       commitish: output/commit.txt
       globs: [ output/eirini-extensions-*.tgz ]

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -22,6 +22,10 @@
 {{- $ = merge (index $.repos "trigger" | default true | dict "trigger" | dict "repos") $ -}}
 {{- /* .repos.org */ -}}
 {{- $ = merge (index $.repos "org" | default "SUSE" | dict "org" | dict "repos") $ -}}
+{{- /* .repos.token */ -}}
+{{- $ = merge (index $.repos "token" | default "((github-access-token))" | dict "token" | dict "repos") $ -}}
+{{- /* .repos.key */ -}}
+{{- $ = merge (index $.repos "key" | default "((github-private-key))" | dict "key" | dict "repos") $ -}}
 {{- /* .repos.<repo> */ -}}
 {{- range $repos -}}
 {{- $ = merge (index $.repos . | default (printf "%s/%s" $.repos.org .) | dict . | dict "repos") $ -}}
@@ -114,6 +118,14 @@ resources:
     branch: master
     uri: https://github.com/{{ index $.repos . }}
 {{ end }}
+- name: github-release.chart
+  type: github-release
+  source:
+    owner: {{ $.repos.org }}
+    repository: eirinix-helm-release
+    access_token: {{ $.repos.token }}
+    release: false
+    pre_release: true
 
 # Docker image outputs
 {{ range $images }}
@@ -123,16 +135,6 @@ resources:
     repository: {{ $.docker.repository }}/eirinix-{{ . }}
     username:   ((docker-username))
     password:   ((docker-password))
-- name: s3.{{ . }}-version
-  type: s3
-  source:
-    bucket: {{ $.s3.bucket }}
-    {{- range keys $.s3 }}
-    {{- if has (slice "bucket" "prefix") . | not }}
-    {{ . }}: {{ index $.s3 . }}
-    {{- end }}
-    {{- end }}
-    regexp: {{ $.s3.prefix | default ""  }}image-{{ . }}-tag-(.*).txt
 {{ end }}
 - name: docker.base
   type: docker-image
@@ -146,8 +148,9 @@ resources:
     username:   ((docker-username))
     password:   ((docker-password))
 
-# S3 bucket for chart
-- name: s3.chart
+# S3 resources
+{{ range $images }}
+- name: s3.{{ . }}-version
   type: s3
   source:
     bucket: {{ $.s3.bucket }}
@@ -156,7 +159,8 @@ resources:
     {{ . }}: {{ index $.s3 . }}
     {{- end }}
     {{- end }}
-    regexp: {{ $.s3.prefix | default "" }}eirini-extensions-(.*).tgz
+    regexp: {{ $.s3.prefix | default ""  }}image-{{ . }}-tag-(.*).txt
+{{ end }}
 
 jobs:
 # group logging
@@ -229,6 +233,8 @@ jobs:
         - --destination=../output
     image: docker.package-base
     params:
+      VERSION_FILE: ../output/version.txt
+      COMMIT_HASH_FILE: ../output/commit.txt
       OVERRIDES: |
         {{- range $images }}
         {{- if . | strings.HasSuffix "-setup" | not }}
@@ -250,7 +256,19 @@ jobs:
           setup-image:
             repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
-  - put: s3.chart
+  - task: release-prep
+    config:
+      platform: linux
+      outputs:
+      - name: release-prep
+      run:
+        path: /bin/sh
+        args: [ -c, "echo -n v > release-prep/tag-prefix.txt" ]
+    image: docker.package-base
+  - put: github-release.chart
     params:
-      file: output/eirini-extensions-*.tgz
-      acl: public-read
+      name: output/version.txt
+      tag: output/version.txt
+      tag_prefix: release-prep/tag-prefix.txt
+      commitish: output/commit.txt
+      globs: [ output/eirini-extensions-*.tgz ]

--- a/bin/package
+++ b/bin/package
@@ -17,10 +17,9 @@ trap cleanup EXIT
 echo "Copying chart to temporary directory..."
 cp -r chart/* "${dir}"
 
-tag="$(git describe --tag --abbrev=0 || echo "0.0.0")"
+tag="$(git describe --tag --abbrev=0 --exclude '*+g*' || echo "0.0.0")"
 commits="$(git rev-list --count --first-parent HEAD)"
-time="$(date --utc +%s)"
-hash="$(git log -1 --pretty=%h)"
+hash="$(git log -1 --pretty=%H)"
 extra=""
 
 if [[ -n "${OVERRIDES:-}" ]] ; then
@@ -30,15 +29,15 @@ if [[ -n "${OVERRIDES:-}" ]] ; then
     extra=".$(sha256sum "${dir}/.overrides.yaml" | head -c 8)"
     rm "${dir}/.overrides.yaml"
 fi
-version="${tag#v}-${commits}.${time}+g${hash}${extra}"
+version="${tag#v}-${commits}+g${hash:0:8}"
 
 # Save information for the concourse pipeline, if requested.
 if [[ -n "${VERSION_FILE:-}" ]] ; then
-    echo "${version}" > "${VERSION_FILE}"
+    echo -n "${version}" > "${VERSION_FILE}"
 fi
 if [[ -n "${COMMIT_HASH_FILE:-}" ]] ; then
-    echo "${hash}" > "${COMMIT_HASH_FILE}"
+    echo -n "${hash}" > "${COMMIT_HASH_FILE}"
 fi
 
 echo "Packaging chart..."
-helm package "${dir}" --version="${version}" "${@}"
+helm package "${dir}" --version="${version}${extra}" "${@}"

--- a/bin/package
+++ b/bin/package
@@ -14,6 +14,7 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+echo "Copying chart to temporary directory..."
 cp -r chart/* "${dir}"
 
 tag="$(git describe --tag --abbrev=0 || echo "0.0.0")"
@@ -23,6 +24,7 @@ hash="$(git log -1 --pretty=%h)"
 extra=""
 
 if [[ -n "${OVERRIDES:-}" ]] ; then
+    echo "Applying values.yaml overrides..."
     echo "${OVERRIDES}" | erb > "${dir}/.overrides.yaml"
     ruby bin/merge-yaml.rb chart/values.yaml "${dir}/.overrides.yaml" "${dir}/values.yaml"
     extra=".$(sha256sum "${dir}/.overrides.yaml" | head -c 8)"
@@ -30,5 +32,13 @@ if [[ -n "${OVERRIDES:-}" ]] ; then
 fi
 version="${tag#v}-${commits}.${time}+g${hash}${extra}"
 
-set -o xtrace
+# Save information for the concourse pipeline, if requested.
+if [[ -n "${VERSION_FILE:-}" ]] ; then
+    echo "${version}" > "${VERSION_FILE}"
+fi
+if [[ -n "${COMMIT_HASH_FILE:-}" ]] ; then
+    echo "${hash}" > "${COMMIT_HASH_FILE}"
+fi
+
+echo "Packaging chart..."
 helm package "${dir}" --version="${version}" "${@}"

--- a/bin/package
+++ b/bin/package
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 # This script packages the helm chart, with a values.yaml that has been modified
-# to contain image tags as passed via environment variables.  The variables are
-# named TAG_FILE_xxx where xxx is the image (e.g. TAG_FILE_LOGGREGATOR_BRIDGE
-# for the loggregator-bridge image), and points to a file that contains the tag
-# to use.  Any options given are passed to `helm package`.
+# by merging with the YAML file contained in the environment variable named
+# `OVERRIDE`.  If the variable `OUTPUT_DIR` is set, the helm chart is output
+# into that directory.  Any options are given to passed to `helm package`.
 
 set -o errexit -o nounset -o pipefail
 
@@ -17,9 +16,12 @@ trap cleanup EXIT
 echo "Copying chart to temporary directory..."
 cp -r chart/* "${dir}"
 
+echo ".output" >> "${dir}/.helmignore"
+
 tag="$(git describe --tag --abbrev=0 --exclude '*+g*' || echo "0.0.0")"
 commits="$(git rev-list --count --first-parent HEAD)"
-hash="$(git log -1 --pretty=%H)"
+hash="$(git log -1 --pretty=%h)"
+time="$(date +%s)"
 extra=""
 
 if [[ -n "${OVERRIDES:-}" ]] ; then
@@ -29,15 +31,18 @@ if [[ -n "${OVERRIDES:-}" ]] ; then
     extra=".$(sha256sum "${dir}/.overrides.yaml" | head -c 8)"
     rm "${dir}/.overrides.yaml"
 fi
-version="${tag#v}-${commits}+g${hash:0:8}"
+version="${tag#v}-${commits}+g${hash}"
 
 # Save information for the concourse pipeline, if requested.
 if [[ -n "${VERSION_FILE:-}" ]] ; then
     echo -n "${version}" > "${VERSION_FILE}"
 fi
 if [[ -n "${COMMIT_HASH_FILE:-}" ]] ; then
-    echo -n "${hash}" > "${COMMIT_HASH_FILE}"
+    git log -1 --pretty=%H | tr -d '\n' > "${COMMIT_HASH_FILE}"
 fi
 
 echo "Packaging chart..."
-helm package "${dir}" --version="${version}${extra}" "${@}"
+mkdir -p "${dir}/.output"
+helm package "${dir}" "${@}" --version="${version}" --destination="${dir}/.output/"
+mv "${dir}/.output/eirini-extensions-${version}.tgz" \
+    "${OUTPUT_DIR:-.}/eirini-extensions-${tag#v}-${commits}-${time}+g${hash}${extra}.tgz"

--- a/bin/update-helm-index.rb
+++ b/bin/update-helm-index.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+
+# This script rebuilds the helm repository index.yaml to add a new entry (or
+# update, if the version already exists), such that the download URL points to
+# GitHub releases.  The changes will be comitted to git.
+
+# Usage:
+#  REPO=<repo> $0 <dir>
+
+# <dir>: A directory that contains:
+#    "tag": A file with the git tag for the GitHub release
+#    "eirini-extensions-*.tgz": The chart.
+
+# The working directory must be a git repository for the helm repository.  If a
+# "index.yaml" exists in the working directory, it will be updated; otherwise, a
+# new file is created.
+
+# Required environment variables:
+#   REPO:   The path of the GitHub repository, such as "SUSE/eirinix-helm-release"
+
+# Optional environment variables:
+#   GIT_AUTHOR_NAME:   If set, git will use this as the author name.
+#   GIT_AUTHOR_EMAIL:  If set, git will use this as the author email.
+
+require 'date'
+require 'digest'
+require 'erb'
+require 'rubygems/package'
+require 'yaml'
+require 'zlib'
+
+# Given a path to a helm chart (tgz bundle), return its Charts.yaml contents
+# as a hash.
+def read_chart(path)
+    file = Gem::Package::TarReader.new(Zlib::GzipReader.open(path))
+    entry = file.find { |entry| entry.full_name =~ /^[^\/]+\/Chart\.yaml$/ }
+    YAML.load(entry.read)
+end
+
+# The path to the directory containing the chart and version info
+def files_dir
+    ARGV.last
+end
+
+# The name of the chart bundle (*.tgz)
+def tar_file_name
+    $tar_file_name ||= Dir.glob('eirini-extensions-*.tgz', base: files_dir).sort.last
+end
+
+# Path to the chart bundle (*.tgz)
+def tar_file_path
+    File.join(files_dir, tar_file_name)
+end
+
+def tag
+    $tag ||= File.read(File.join(files_dir, 'tag')).strip
+end
+
+# The URL to download the chart
+def chart_url
+    repo = ENV['REPO']
+    fail 'Environment variable REPO is missing' unless repo
+    url_tag = ERB::Util.url_encode tag
+    file = ERB::Util.url_encode tar_file_name
+    "https://github.com/#{repo}/releases/download/#{url_tag}/#{file}"
+end
+
+# The entry in index.yaml for this chart version
+def build_entry
+    wanted_keys = %w(apiVersion description name version)
+    chart_info = read_chart(tar_file_path).select { |k, v| wanted_keys.include? k }
+    digest = Digest::SHA256.file(tar_file_path).hexdigest
+    result = chart_info.merge(
+        created: File.ctime(tar_file_path).to_datetime.rfc3339,
+        digest: digest,
+        urls: [ chart_url ],
+    )
+    # Do a sort on the keys to match output of the official helm CLI
+    Hash[result.transform_keys(&:to_s).to_a.sort]
+end
+
+index = begin
+    YAML.load_file('index.yaml')
+rescue Errno::ENOENT
+    {
+        apiVersion: 'v1',
+        entries: {},
+    }.transform_keys(&:to_s)
+end
+entry = build_entry
+entries = index['entries'][entry['name']] ||= []
+old_entry = entries.find { |e| e['version'] == entry['version']}
+if old_entry.nil?
+    entries << entry
+    message = "Add version #{entry['version']}"
+else
+    old_entry.merge! entry
+    message = "Update version #{entry['version']}"
+end
+index['generated'] = DateTime.now.rfc3339
+
+File.open('index.yaml', 'w') { |f| YAML.dump(index, f) }
+
+Process.wait Process.spawn('git', 'add', 'index.yaml')
+fail "Git add returned #{$?.exitstatus}" unless $?.success?
+git_command = %w(git)
+ENV['GIT_AUTHOR_NAME'].tap { |n| git_command += ['-c', "user.name=#{n}"] if n }
+ENV['GIT_AUTHOR_EMAIL'].tap { |e| git_command += ['-c', "user.email=#{e}"] if e }
+git_command += [ 'commit', '-m', message ]
+
+exec *git_command


### PR DESCRIPTION
_(Note: This is based on #5 and should be looked at after that.)_

When I did https://github.com/cloudfoundry-incubator/kubecf/issues/653 I misread the description and didn't do what it asked: the charts were not being published as GitHub releases.  This PR does the following:

- Push the build charts to GitHub releases instead of S3.  See [mook-as/eirinix-helm-release/releases](https://github.com/mook-as/eirinix-helm-release/releases) for a sample.  Note that I kept amending, hence all the `0.0.0-20` releases; only one per commit should exist in the actual repository.
- Generate `index.yaml` in the `gh-pages` branch of the repository.  See [mook-as/eirinix-helm-release#gh-pages](https://github.com/mook-as/eirinix-helm-release/blob/gh-pages/index.yaml) for an example.
