### PR TITLE
fix: Attempt to publish repo via github actions

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -102,7 +102,7 @@
 
 groups:
 - name: chart
-  jobs: [ package-base, chart, update-repo ]
+  jobs: [ package-base, chart ]
 - name: logging
   jobs: [ loggregator-bridge ]
 - name: persi
@@ -119,12 +119,6 @@ resources:
     branch: master
     uri: https://github.com/{{ index $.repos . }}
 {{ end }}
-- name: git.chart-repository
-  type: git
-  source:
-    branch: gh-pages
-    uri: git@github.com:{{ index $.repos "eirinix-helm-release" }}
-    private_key: {{ $.repos.key }}
 - name: github-release.chart
   type: github-release
   source:
@@ -269,36 +263,4 @@ jobs:
       tag_prefix: v
       commitish: output/commit.txt
       globs: [ output/eirini-extensions-*.tgz ]
-- name: update-repo
-  serial: true
-  plan:
-  - in_parallel:
-    - get: docker.package-base
-    - get: git.eirinix-helm-release
-    - get: git.chart-repository
-    - get: github-release.chart
-      trigger: {{ $.repos.trigger }}
-      passed: [ chart ]
-      params:
-        globs: [ eirini-extensions-*.tgz ]
-  - task: regenerate-chart-repo
-    config:
-      platform: linux
-      inputs:
-      - name: git.chart-repository
-      - name: git.eirinix-helm-release
-      - name: github-release.chart
-      outputs:
-      - name: git.chart-repository
-      params:
-        GIT_AUTHOR_NAME: {{ $.git.user }}
-        GIT_AUTHOR_EMAIL: {{ $.git.email }}
-        REPO: {{ index $.repos "eirinix-helm-release" }}
-      run:
-        path: ../git.eirinix-helm-release/bin/update-helm-index.rb
-        dir: git.chart-repository
-        args: [ ../github-release.chart ]
-    image: docker.package-base
-  - put: git.chart-repository
-    params:
-      repository: git.chart-repository
+      body: output/body.txt

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,33 @@
+name: Publish helm chart
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+      with:
+        path: git.eirinix-helm-release
+    - name: Checkout helm repository
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ github.repository_owner }}/eirinix-helm-release
+        ref: gh-pages
+        path: git.chart-repository
+    - name: Regenerate index
+      run: >
+        ruby
+        ${{ github.workspace }}/git.eirinix-helm-release/bin/update-helm-index.rb
+        ${{ github.workspace }}/github-release.chart
+      env:
+        REPO: ${{ github.repository }}
+        GIT_AUTHOR_NAME: CI Bot
+        GIT_AUTHOR_EMAIL: ${{ github.repository_owner }}@noreply.github.io
+      working-directory: git.chart-repository
+    - name: Push index
+      run: git push
+      working-directory: git.chart-repository

--- a/bin/package
+++ b/bin/package
@@ -33,6 +33,8 @@ if [[ -n "${OVERRIDES:-}" ]] ; then
 fi
 version="${tag#v}-${commits}+g${hash}"
 
+filename="eirini-extensions-${tag#v}-${commits}-${time}+g${hash}${extra}.tgz"
+
 # Save information for the concourse pipeline, if requested.
 if [[ -n "${VERSION_FILE:-}" ]] ; then
     echo -n "${version}" > "${VERSION_FILE}"
@@ -44,5 +46,10 @@ fi
 echo "Packaging chart..."
 mkdir -p "${dir}/.output"
 helm package "${dir}" "${@}" --version="${version}" --destination="${dir}/.output/"
-mv "${dir}/.output/eirini-extensions-${version}.tgz" \
-    "${OUTPUT_DIR:-.}/eirini-extensions-${tag#v}-${commits}-${time}+g${hash}${extra}.tgz"
+mv "${dir}/.output/eirini-extensions-${version}.tgz" "${OUTPUT_DIR:-.}/${filename}"
+
+if [ -n "${OUTPUT_DIR:-}" ] ; then
+    # For CI builds, we want a body text that changes every time so that the
+    # helm chart repository will get updated
+    echo "Automated release ${filename}" > "${OUTPUT_DIR}/body.txt"
+fi

--- a/bin/update-helm-index.rb
+++ b/bin/update-helm-index.rb
@@ -3,20 +3,19 @@
 # This script rebuilds the helm repository index.yaml to add a new entry (or
 # update, if the version already exists), such that the download URL points to
 # GitHub releases.  The changes will be comitted to git.
+# This is expected to run from a GitHub action.
 
 # Usage:
-#  REPO=<repo> $0 <dir>
-
-# <dir>: A directory that contains:
-#    "tag": A file with the git tag for the GitHub release
-#    "eirini-extensions-*.tgz": The chart.
+#  REPO=<repo> GITHUB_TOKEN=<token> GITHUB_REF=<ref> $0
 
 # The working directory must be a git repository for the helm repository.  If a
 # "index.yaml" exists in the working directory, it will be updated; otherwise, a
 # new file is created.
 
 # Required environment variables:
-#   REPO:   The path of the GitHub repository, such as "SUSE/eirinix-helm-release"
+#   REPO:         The path of the GitHub repository, such as "SUSE/eirinix-helm-release"
+#   GITHUB_TOKEN: OAuth token to use for authentication
+#   GITHUB_REF:   GitHub release tag, possiby prefixed by "refs/tags/"
 
 # Optional environment variables:
 #   GIT_AUTHOR_NAME:   If set, git will use this as the author name.
@@ -25,7 +24,9 @@
 require 'date'
 require 'digest'
 require 'erb'
+require 'json'
 require 'rubygems/package'
+require 'tempfile'
 require 'yaml'
 require 'zlib'
 
@@ -37,32 +38,36 @@ def read_chart(path)
     YAML.load(entry.read)
 end
 
-# The path to the directory containing the chart and version info
-def files_dir
-    ARGV.last
+def repo
+    fail 'Environment variable REPO is missing' unless ENV['REPO']
+    ENV['REPO']
 end
 
-# The name of the chart bundle (*.tgz)
-def tar_file_name
-    $tar_file_name ||= Dir.glob('eirini-extensions-*.tgz', base: files_dir).sort.last
+def tag
+    fail 'Environment variable GITHUB_REF is missing' unless ENV['GITHUB_REF']
+    ENV['GITHUB_REF'].delete_prefix 'refs/tags/'
+end
+
+def curl
+    %Q<curl --header 'Authorization: #{ENV['GITHUB_TOKEN']}'>
+end
+
+def release
+    url = "https://api.github.com/repos/#{repo}/releases/tags/#{tag}"
+    JSON.load(`#{curl} '#{url}'`)
+end
+
+def chart_url
+    release['assets'].first['browser_download_url']
 end
 
 # Path to the chart bundle (*.tgz)
 def tar_file_path
-    File.join(files_dir, tar_file_name)
-end
-
-def tag
-    $tag ||= File.read(File.join(files_dir, 'tag')).strip
-end
-
-# The URL to download the chart
-def chart_url
-    repo = ENV['REPO']
-    fail 'Environment variable REPO is missing' unless repo
-    url_tag = ERB::Util.url_encode tag
-    file = ERB::Util.url_encode tar_file_name
-    "https://github.com/#{repo}/releases/download/#{url_tag}/#{file}"
+    return $tar_file.path unless $tar_file.nil?
+    $tar_file = Tempfile.new(['eirinix-chart-', '.tgz']).tap(&:close)
+    Process.wait Process.spawn('curl', '-L', '-o', $tar_file.path, chart_url)
+    fail "Could not download file" unless $?.success?
+    $tar_file.path
 end
 
 # The entry in index.yaml for this chart version
@@ -97,6 +102,7 @@ else
     old_entry.merge! entry
     message = "Update version #{entry['version']}"
 end
+puts "#{message} with #{entry['urls'].first}"
 index['generated'] = DateTime.now.rfc3339
 
 File.open('index.yaml', 'w') { |f| YAML.dump(index, f) }


### PR DESCRIPTION
Having issues with the github-release concourse resource (it's not triggering builds when assets are uploaded); trying with github actions instead.

Ends up we also need to have a release body text to force the change to be recognized as an edit.  Put in the file name as we need to regenerate the index whenever the file name changes.

This is a checkpoint for my work today — if desired, I can undo the relevant changes and not use a GitHub Action (instead relying on github-release-resource to detect the edit to the release) tomorrow, if desired.  Assuming that works.