### PR TITLE
feat: CI: allow overrides for docker credentials

### DIFF
--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -3,6 +3,8 @@
 
 docker:
   repository: ~ # splatform
+  username: ((docker-username))
+  password: ((docker-password))
 
 git:
   user: ~  # SUSE CFCIBot

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -10,6 +10,10 @@
 {{- $ = dict | dict "docker" | merge $ -}}
 {{- /* .docker.repository */ -}}
 {{- $ = merge (index $.docker "repository" | default "splatform" | dict "repository" | dict "docker") $ -}}
+{{- /* .docker.username */ -}}
+{{- $ = merge (index $.docker "username" | default "((docker-username))" | dict "username" | dict "docker") $ -}}
+{{- /* .docker.password */ -}}
+{{- $ = merge (index $.docker "password" | default "((docker-password))" | dict "password" | dict "docker") $ -}}
 {{- /* .git */ -}}
 {{- $ = dict | dict "git" | merge $ -}}
 {{- /* .git.user */ -}}
@@ -134,8 +138,8 @@ resources:
   type: docker-image
   source:
     repository: {{ $.docker.repository }}/eirinix-{{ . }}
-    username:   ((docker-username))
-    password:   ((docker-password))
+    username:   {{ $.docker.username }}
+    password:   {{ $.docker.password }}
 {{ end }}
 - name: docker.base
   type: docker-image
@@ -146,8 +150,8 @@ resources:
   type: docker-image
   source:
     repository: {{ $.docker.repository }}/eirinix-package-base
-    username:   ((docker-username))
-    password:   ((docker-password))
+    username:   {{ $.docker.username }}
+    password:   {{ $.docker.password }}
 
 # S3 resources
 {{ range $images }}


### PR DESCRIPTION
This is useful on concourse deployments where the secrets for docker authentication are named differently. This should have no effect on the production deployment (the old secret names are the default values).