### PR TITLE
Remove prefix from the resources.

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -28,7 +28,7 @@ If release name contains chart name it will be used as a full name.
 Expand the name of a component.
 */}}
 {{- define "eirinix.component-name" -}}
-{{- printf "%s-%s" .Release.Name .name | trunc 63 | trimSuffix "-" -}}
+{{- .name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
See https://github.com/cloudfoundry-incubator/kubecf/issues/817

Tested locally with a minikube and kubecf requirements.yaml redirected to a local webserver/helm repo to serve the modified chart.

Pods from the deployments now look like below, with the `kubecf-` prefix stripped.
```
kubecf        loggregator-bridge-7bc57d9d7d-8w7lv  1/1     Running   0    16m
kubecf        persi-9f98c68d9-rt2cs                1/1     Running   0    16m
kubecf        persi-broker-798ccbb894-qjjbv        1/1     Running   0    16m
kubecf        ssh-558779dc8-hgdb6                  1/1     Running   0    16m
kubecf        ssh-proxy-85b944556d-nqm46           1/1     Running   0    16m
```
