### PR TITLE
Switch chart to nil for the default kube storage class of the broker.

### DIFF
--- a/.concourse/README.md
+++ b/.concourse/README.md
@@ -32,5 +32,5 @@ Deploy the pipeline using the `fly` script in this directory:
 ### Pipeline development
 
 If you wish to deploy a copy of this pipeline for development (without
-publishing) artifacts to the official places), create a `configl.yaml` file
+publishing) artifacts to the official places), create a `config.yaml` file
 based on `config.yaml.sample` and deploy normally.

--- a/chart/templates/persi-broker.yaml
+++ b/chart/templates/persi-broker.yaml
@@ -47,7 +47,7 @@ spec:
                   kube_storage_class: {{ . }}
                   {{- end }}
                   free: {{ .free }}
-                  deault_size: {{ .default_size }}
+                  default_size: {{ .default_size }}
                 {{- end }}
               description: {{ .description }}
               long_description: {{ .long_description }}

--- a/chart/templates/persi-broker.yaml
+++ b/chart/templates/persi-broker.yaml
@@ -43,7 +43,9 @@ spec:
                 - plan_id: {{ .id }}
                   plan_name: {{ .name }}
                   description: {{ .description }}
-                  kube_storage_class: {{ .kube_storage_class }}
+		  {{ with .kube_storage_class }}
+                  kube_storage_class: {{ . }}
+                  {{- end }}
                   free: {{ .free }}
                   deault_size: {{ .default_size }}
                 {{- end }}

--- a/chart/templates/persi-broker.yaml
+++ b/chart/templates/persi-broker.yaml
@@ -43,7 +43,7 @@ spec:
                 - plan_id: {{ .id }}
                   plan_name: {{ .name }}
                   description: {{ .description }}
-		  {{ with .kube_storage_class }}
+                  {{- with .kube_storage_class }}
                   kube_storage_class: {{ . }}
                   {{- end }}
                   free: {{ .free }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -53,7 +53,7 @@ persi-broker:
   - id: default
     name: "default"
     description: "Existing default storage class"
-    kube_storage_class: "default"
+    kube_storage_class: ~
     free: true
     default_size: "1Gi"
   description: Eirini persistence broker


### PR DESCRIPTION
See https://github.com/cloudfoundry-incubator/kubecf/issues/819

By not specifying an SC we can make use of the DefaultSC admission plugin
to get something sensible in a more complex deployment with many helm charts
and sub charts.

# Testing

This pull request is one in a group of 3 related PRs.
They have to be reviewed and tested together.
The instructions for such are found at https://github.com/cloudfoundry-incubator/kubecf/issues/819#issuecomment-649841863
The full set of PRs is listed in the description of https://github.com/cloudfoundry-incubator/kubecf/issues/819
