### PR TITLE
Bring the kubecf#1027 ssh-proxy change into the chart proper.

### DIFF
--- a/chart/templates/ssh-proxy.yaml
+++ b/chart/templates/ssh-proxy.yaml
@@ -131,7 +131,17 @@ spec:
     protocol: TCP
     port: 2222
     targetPort: 2222
-  type: ClusterIP
-  {{- if gt (len .Values.externalIPs) 0 }}
-  externalIPs: {{ .Values.externalIPs | toJson }}
+  {{- with index .Values $component }}
+  {{- if .type }}
+  type: {{ .type | quote }}
+  {{- end}}
+
+  {{- if gt (len .externalIPs) 0 }}
+  externalIPs: {{ .externalIPs | toJson }}
+  {{- end }}
+  {{- if .clusterIP }}
+  clusterIP: {{ .clusterIP | quote }}
+  {{- end }}
+  {{- if .loadBalancerIP }}
+  loadBalancerIP: {{ .loadBalancerIP | quote }}
   {{- end }}


### PR DESCRIPTION
The change was done locally in kubecf only, and the next regular
update of the sub-charts then killed that local change, breaking ssh.

See https://github.com/cloudfoundry-incubator/kubecf/pull/1027 for the origin of the change,
and https://github.com/cloudfoundry-incubator/kubecf/pull/1077 where it got broken.
