### PR TITLE
Adding two forgotten changes from the #1027 loss.

### DIFF
--- a/chart/templates/ssh-proxy.yaml
+++ b/chart/templates/ssh-proxy.yaml
@@ -145,3 +145,4 @@ spec:
   {{- if .loadBalancerIP }}
   loadBalancerIP: {{ .loadBalancerIP | quote }}
   {{- end }}
+  {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -70,7 +70,7 @@ ssh:
   replicaCount: 1
   image:
     repository: splatform
-    tag: latest
+    tag: v0.0.0-0.g04a3871
     pullPolicy: IfNotPresent
   resources: {}
   nodeSelector: {}
@@ -94,6 +94,7 @@ ssh-proxy:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  externalIPs: []
 
   secrets:
     host-keys: var-diego-ssh-proxy-host-key


### PR DESCRIPTION
Attention: The ssh tag points to the specific image needed by the kubecf#1027 PR.
This (likely) has to be changed back to latest when latest goes beyond that in the future.